### PR TITLE
Update Dockerfile to build in Ubuntu 22.04, MacOS and Windows 11 envi…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,6 +70,7 @@ RUN colcon mixin add default \
 
 # install ros2 dashing 
 RUN apt-get update -y
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y ros-foxy-desktop
 
 # install basics
@@ -86,6 +87,7 @@ RUN pip3 install tarjan pyyaml pydot
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt install -y python3.6
+RUN apt install -y python3.6-distutils
 RUN python3.6 -m pip install tarjan
 RUN apt-get install -y default-jdk
 

--- a/examples/ardupilot/vagrant/Vagrantfile
+++ b/examples/ardupilot/vagrant/Vagrantfile
@@ -227,6 +227,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       pip3 install tarjan pyyaml pydot
       sudo add-apt-repository ppa:deadsnakes/ppa
       sudo apt install -y python3.6
+      sudo apt install -y python3.6-distutils
       python3.6 -m pip install tarjan
       cd ~
       git clone https://github.com/SRI-CSL/radler.git


### PR DESCRIPTION
…ronments

When building this docker, there were errors in the Ubuntu 22.04 system at the `ros-foxy-desktop` install steps that left the build requesting interaction for language (see build results for Ubuntu below).  Once that was solved, all environment (Ubuntu 22.04, MacOS and Windows 11) showed the other issue with the `python3.6 -m pip install tarjan` command (see build results for MacOS and WIndows 11 below).  This one needed distutil for python 3.6 before this command.

Docker Build Results for Ubuntu 22.04 system (prior to modifications):
```
temp/radler/docker$ docker build -t radler/ros2 .
[+] Building 856.1s (15/34)                                                                                                 docker:desktop-linux
[+] Building 865.5s (15/34)                                                                                                 docker:desktop-linux
[+] Building 1714.8s (15/34)                                                                                                docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                  0.0s
 => => transferring dockerfile: 3.12kB                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/ubuntu:focal                                                                                                                               0.9s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                               0.0s
 => [ 1/30] FROM docker.io/library/ubuntu:focal@sha256:0b897358ff6624825fb50d20ffb605ab0eaea77ced0adb8c6a4b756513dec6fc          1.5s
 => => resolve docker.io/library/ubuntu:focal@sha256:0b897358ff6624825fb50d20ffb605ab0eaea77ced0adb8c6a4b756513dec6fc               0.0s
 => => sha256:0b897358ff6624825fb50d20ffb605ab0eaea77ced0adb8c6a4b756513dec6fc 1.13kB / 1.13kB                                                   0.0s
 => => sha256:d86db849e59626d94f768c679aba441163c996caf7a3426f44924d0239ffe03f 424B / 424B                                                         0.0s
 => => sha256:5f5250218d28ad6612bf653eced407165dd6475a4daf9210b299fed991e172e9 2.30kB / 2.30kB                                                 0.0s
 => => sha256:9ea8908f47652b59b8055316d9c0e16b365e2b5cee15d3efcb79e2957e3e7cad 27.51MB / 27.51MB                                         0.8s
 => => extracting sha256:9ea8908f47652b59b8055316d9c0e16b365e2b5cee15d3efcb79e2957e3e7cad                                                         0.5s
 => [internal] load build context                                                                                                                                                                                0.0s
 => => transferring context: 636B                                                                                                                                                                            0.0s
 => [ 2/30] RUN echo 'Etc/UTC' > /etc/timezone &&     ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime &&     apt-get update && apt-get in       5.6s
 => [ 3/30] RUN apt-get update && apt-get install -q -y     bash-completion     dirmngr     gnupg2     lsb-release     python3-pip     &&               25.9s
 => [ 4/30] RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654  0.9s
 => [ 5/30] RUN echo "deb http://packages.ros.org/ros2/ubuntu lsb_release -sc main" > /etc/apt/sources.list.d/ros2-latest.list                    0.2s
 => [ 6/30] RUN apt-get update && apt-get install --no-install-recommends -y     git     python3-rosdep     python3-vcstool     && rm -rf               9.8s
 => [ 7/30] RUN pip3 install -U     argcomplete     colcon-common-extensions     colcon-mixin     flake8     flake8-blind-except     flake                8.2s
 => [ 8/30] RUN pip3 freeze | grep pytest     && python3 -m pytest --version                                                                                                           0.8s
 => [ 9/30] RUN rosdep init     && rosdep update                                                                                                                                                      7.2s
 => [10/30] RUN colcon mixin add default       https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml &&     c       6.5s
 => [11/30] RUN apt-get update -y                                                                                                                                                                             4.0s
 => [12/30] RUN apt-get install -y ros-foxy-desktop                                                                                                                                             1643.3s
 => => #   95. Ukrainian
 => => #   96. Urdu (Pakistan)
 => => #   97. Uzbek
 => => #   98. Vietnamese
 => => #   99. Wolof
 => => # Country of origin for the keyboard:
```

Docker Build Results for Windows 11 and MacOS (prior to modifications)
```
docker % docker build -t radler/ros2 .
[+] Building 1214.3s (28/34)                                                                                                                                    docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                             0.0s
 => => transferring dockerfile: 3.12kB                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/ubuntu:focal                                                                                                          1.0s
 => [internal] load .dockerignore                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                          0.0s
 => => transferring context: 636B                                                                                                                                                      0.0s
 => [ 1/30] FROM docker.io/library/ubuntu:focal@sha256:0b897358ff6624825fb50d20ffb605ab0eaea77ced0adb8c6a4b75651  1.5s
 => => resolve docker.io/library/ubuntu:focal@sha256:0b897358ff6624825fb50d20ffb605ab0eaea77ced0adb8c6a4b756513d   0.0s
 => => sha256:f02209be4ee528c246399de81af4552e52adb005a8a499815607b6b0d42746bf 25.97MB / 25.97MB                     0.7s
 => => sha256:0b897358ff6624825fb50d20ffb605ab0eaea77ced0adb8c6a4b756513dec6fc 1.13kB / 1.13kB                               0.0s
 => => sha256:6edb9576e2a2080a42e4e0e9a6bc0bd91a2bf06375f9832d400bf33841d35ece 424B / 424B                                 0.0s
 => => sha256:583f1722e16e377baf906fee1ec6a9fda85ff7f3d13f536f912998601fd85ed8 2.31kB / 2.31kB                                  0.0s
 => => extracting sha256:f02209be4ee528c246399de81af4552e52adb005a8a499815607b6b0d42746bf                                     0.7s
 => [ 2/30] RUN echo 'Etc/UTC' > /etc/timezone &&     ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime &&     a                           34.9s
 => [ 3/30] RUN apt-get update && apt-get install -q -y     bash-completion     dirmngr     gnupg2     lsb-rel                                 120.6s
 => [ 4/30] RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6   0.6s
 => [ 5/30] RUN echo "deb http://packages.ros.org/ros2/ubuntu lsb_release -sc main" > /etc/apt/sources.list.d/                     0.1s
 => [ 6/30] RUN apt-get update && apt-get install --no-install-recommends -y     git     python3-rosdep     pyt                               49.7s
 => [ 7/30] RUN pip3 install -U     argcomplete     colcon-common-extensions     colcon-mixin     flake8     fla                                 7.1s
 => [ 8/30] RUN pip3 freeze | grep pytest     && python3 -m pytest --version                                                                                    0.6s
 => [ 9/30] RUN rosdep init     && rosdep update                                                                                                                               6.4s
 => [10/30] RUN colcon mixin add default       https://raw.githubusercontent.com/colcon/colcon-mixin-repository/                          3.8s
 => [11/30] RUN apt-get update -y                                                                                                                                                    33.4s
 => [12/30] RUN apt-get install -y ros-foxy-desktop                                                                                                                        924.5s
 => [13/30] RUN apt-get install -y tmux                                                                                                                                               2.0s
 => [14/30] RUN apt-get install -y net-tools iputils-ping                                                                                                                      1.7s
 => [15/30] RUN apt-get install -y openssh-server openssh-client                                                                                                     3.8s
 => [16/30] RUN apt-get install -y libncurses5-dev                                                                                                                             2.2s
 => [17/30] RUN apt-get install -y --no-install-recommends vim-tiny                                                                                                  2.8s
 => [18/30] RUN apt-get update -y                                                                                                                                                      1.2s
 => [19/30] RUN apt-get install -y cmake python3-pip                                                                                                                        0.8s
 => [20/30] RUN pip3 install tarjan pyyaml pydot                                                                                                                               1.3s
 => [21/30] RUN apt-get install -y software-properties-common                                                                                                        2.3s
 => [22/30] RUN add-apt-repository ppa:deadsnakes/ppa                                                                                                                3.0s
 => [23/30] RUN apt install -y python3.6                                                                                                                                            8.8s
 => ERROR [24/30] RUN python3.6 -m pip install tarjan                                                                                                                   0.1s
————————
 [24/30] RUN python3.6 -m pip install tarjan:
0.110 Traceback (most recent call last):
0.110   File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
0.110     "main", mod_spec)
0.110   File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
0.110     exec(code, run_globals)
0.110   File "/usr/lib/python3/dist-packages/pip/main.py", line 16, in <module>
0.110     from pip._internal.cli.main import main as _main  # isort:skip # noqa
0.110   File "/usr/lib/python3/dist-packages/pip/_internal/cli/main.py", line 10, in <module>
0.110     from pip._internal.cli.autocompletion import autocomplete
0.110   File "/usr/lib/python3/dist-packages/pip/_internal/cli/autocompletion.py", line 9, in <module>
0.110     from pip._internal.cli.main_parser import create_main_parser
0.110   File "/usr/lib/python3/dist-packages/pip/_internal/cli/main_parser.py", line 7, in <module>
0.110     from pip._internal.cli import cmdoptions
0.110   File "/usr/lib/python3/dist-packages/pip/_internal/cli/cmdoptions.py", line 19, in <module>
0.110     from distutils.util import strtobool
0.110 ModuleNotFoundError: No module named 'distutils.util'
————————
Dockerfile:89
————————
  87 |     RUN add-apt-repository ppa:deadsnakes/ppa
  88 |     RUN apt install -y python3.6
  89 | >>> RUN python3.6 -m pip install tarjan
  90 |     RUN apt-get install -y default-jdk
  91 |
————————
ERROR: failed to solve: process "/bin/sh -c python3.6 -m pip install tarjan" did not complete successfully: exit code: 1
```